### PR TITLE
[Logrotate] Add logging configuration

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1624,6 +1624,43 @@ class SyslogCfg:
             return interval, burst
         return interval, burst
 
+class LoggingCfg(object):
+    """Logging Config Daemon
+
+    Handles changes in LOGGING table.
+    1) Handle change of debug/syslog log files config
+    """
+    def __init__(self):
+        self.cache = {}
+
+    def load(self, logging_cfg={}):
+        # Get initial logging file configuration
+        self.cache = logging_cfg
+        syslog.syslog(syslog.LOG_DEBUG, f'Initial logging config: {self.cache}')
+
+    def update_logging_cfg(self, key, data):
+        """Apply logging configuration
+
+        The daemon restarts logrotate-config which will regenerate logrotate
+        config files.
+        Args:
+            key:    DB table's key that was triggered change (basically it is a
+                    config file)
+            data:   File's config data
+        """
+        syslog.syslog(syslog.LOG_DEBUG, 'LoggingCfg: logging files cfg update')
+        if self.cache.get(key) != data:
+            syslog.syslog(syslog.LOG_INFO,
+                          f'Set logging file {key} config: {data}')
+            try:
+                run_cmd('sudo systemctl restart logrotate-config', True, True)
+            except Exception:
+                syslog.syslog(syslog.LOG_ERR, f'Failed to update {key} message')
+                return
+
+        # Update cache
+        self.cache[key] = data
+
 class HostConfigDaemon:
     def __init__(self):
         self.state_db_conn = DBConnector(STATE_DB, 0)
@@ -1677,6 +1714,9 @@ class HostConfigDaemon:
         # Initialize SyslogCfg
         self.syslogcfg = SyslogCfg()
 
+        # Initialize LoggingCfg
+        self.loggingcfg = LoggingCfg()
+
     def load(self, init_data):
         features = init_data['FEATURE']
         aaa = init_data['AAA']
@@ -1693,6 +1733,7 @@ class HostConfigDaemon:
         mgmt_ifc = init_data.get(swsscommon.CFG_MGMT_INTERFACE_TABLE_NAME, {})
         mgmt_vrf = init_data.get(swsscommon.CFG_MGMT_VRF_CONFIG_TABLE_NAME, {})
         syslog = init_data.get('SYSLOG_CONFIG', {})
+        logging = init_data.get('LOGGING', {})
 
         self.feature_handler.sync_state_field(features)
         self.aaacfg.load(aaa, tacacs_global, tacacs_server, radius_global, radius_server)
@@ -1703,6 +1744,7 @@ class HostConfigDaemon:
         self.devmetacfg.load(dev_meta)
         self.mgmtifacecfg.load(mgmt_ifc, mgmt_vrf)
         self.syslogcfg.load(syslog)
+        self.loggingcfg.load(logging)
 
         # Update AAA with the hostname
         self.aaacfg.hostname_update(self.devmetacfg.hostname)
@@ -1805,6 +1847,10 @@ class HostConfigDaemon:
     def syslog_handler(self, key, op, data):
         self.syslogcfg.syslog_update(data)
 
+    def logging_handler(self, key, op, data):
+        syslog.syslog(syslog.LOG_INFO, 'LOGGING table handler...')
+        self.loggingcfg.update_logging_cfg(key, data)
+
     def wait_till_system_init_done(self):
         # No need to print the output in the log file so using the "--quiet"
         # flag
@@ -1853,6 +1899,10 @@ class HostConfigDaemon:
                                  make_callback(self.mgmt_vrf_handler))
 
         self.config_db.subscribe('SYSLOG_CONFIG', make_callback(self.syslog_handler))
+
+        # Handle LOGGING changes
+        self.config_db.subscribe(swsscommon.CFG_LOGGING_TABLE_NAME,
+                                 make_callback(self.logging_handler))
 
         syslog.syslog(syslog.LOG_INFO,
                       "Waiting for systemctl to finish initialization")


### PR DESCRIPTION
This PR brings functionality that allows us to update the log rotation configs by writing to the LOGGING table of ConfigDB